### PR TITLE
move bitwardenrs docker hub to vaultwarden

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
-version: '3'
+version: "3"
 
 services:
   bitwarden:
-    image: bitwardenrs/server:alpine
+    image: vaultwarden/server:alpine
     restart: always
     volumes:
       - ./data:/data


### PR DESCRIPTION
The [bitwardenrs/server](https://hub.docker.com/r/bitwardenrs/server) hub is deprecated.
We should move to [vaultwarden/server](https://hub.docker.com/r/vaultwarden/server).

What I did:
- Change `bitwardenrs/server:alpine` to  `vaultwarden/server:alpine` in `docker-compose.yml`
